### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `releaseBranch: master\n1.x` to the build-and-publish action so the 1.x maintenance branch is recognized as a release branch by `enonic/release-tools`.

This PR is part of the XP 8 migration, mirroring the app-booster maintenance-branch pattern. The companion master-side PR upgrades the library to XP 8 and bumps the version to `2.0.0-SNAPSHOT`.

## Test plan
- [ ] CI build on `chore/1.x-add-release-branch` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)