### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation xplibs.io
 
     // Other libs
-    implementation 'commons-net:commons-net:3.13.0'
+    implementation libs.commons.net
 } // dependencies
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+commons-net = "3.13.0"
+
+[libraries]
+commons-net = { module = "commons-net:commons-net", version.ref = "commons-net" }


### PR DESCRIPTION
## Summary

Pin-for-pin migration of the only inline-versioned dependency
(`commons-net:commons-net:3.13.0`) into a new
`gradle/libs.versions.toml`. No version bumps.

## Conventions adopted

- Hyphen-separated, lowercase keys (matches the dominant style across
  the IdeaProjects tree; see `app-features`, `app-adfs-idprovider`,
  `app-cloud-utils`).
- Alphabetical order in `[versions]` and `[libraries]` (only one entry
  today, but this is the rule for future additions).
- `xpVersion` stays in `gradle.properties` (toolchain expects it there);
  `xplibs.*` accessors remain untouched.

## New catalog content

```toml
[versions]
commons-net = "3.13.0"

[libraries]
commons-net = { module = "commons-net:commons-net", version.ref = "commons-net" }
```

## Verification

- `./gradlew build --refresh-dependencies` — green.
- `./gradlew dependencies --configuration runtimeClasspath` diffs only on
  build timing; the resolved tree (`com.enonic.xp:lib-io:8.0.0-B4`,
  `commons-net:commons-net:3.13.0` → `commons-io:commons-io:2.21.0`) is
  identical before and after.

## Test plan

- [x] `./gradlew build --refresh-dependencies` passes locally
- [x] `runtimeClasspath` dependency tree unchanged vs. pre-migration HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)